### PR TITLE
dvm: fix panic

### DIFF
--- a/dvm/events_storage.go
+++ b/dvm/events_storage.go
@@ -19,29 +19,38 @@ func GetStoredEvents(ctx context.Context, filters ...model.Filter) query.EventIt
 
 func (d *dvm) searchDVMEvents(ctx context.Context, filters model.Filters) query.EventIterator {
 	return func(yield func(*model.Event, error) bool) {
+		var doStop bool
 		for index, f := range filters {
+			if ctx.Err() != nil && !doStop {
+				yield(nil, ctx.Err())
+				return
+			} else if doStop {
+				// If we already stopped, we don't need to continue.
+				return
+			}
+
 			if f.Tags.HasValues("p") {
 				for _, e := range d.findByFilterTag(filters, index, "p") {
 					if !yield(e, nil) {
 						return
 					}
 				}
-			} else {
-				d.responseCache.Range(func(item *ttlcache.Item[string, *xsync.Map[string, *model.Event]]) bool {
-					if ctx.Err() != nil {
-						return yield(nil, ctx.Err())
-					}
-					item.Value().Range(func(key string, value *model.Event) bool {
-						if filters.Match(&value.Event) {
-							if !yield(value, nil) {
-								return false
-							}
-						}
-						return true
-					})
-					return true
-				})
+				// We are done with this filter, continue to the next one.
+				continue
 			}
+
+			d.responseCache.Range(func(item *ttlcache.Item[string, *xsync.Map[string, *model.Event]]) bool {
+				item.Value().Range(func(key string, value *model.Event) bool {
+					if model.FiltersMatch(filters, value, "", "") {
+						if !yield(value, nil) {
+							doStop = true
+							return false // Stop iterating over xsync.Map.
+						}
+					}
+					return ctx.Err() == nil && !doStop
+				})
+				return ctx.Err() == nil && !doStop
+			})
 		}
 	}
 }


### PR DESCRIPTION
```
panic: runtime error: range function continued iteration after function for loop body returned false
goroutine 889930 [running]:
github.com/ice-blockchain/subzero/server/ws.(*handler).streamEvents-range1(0x0?, {0x35c59e0?, 0x522cac0?})
        /home/runner/work/subzero/subzero/server/ws/subscriptions.go:397 +0x3d3
github.com/ice-blockchain/subzero/dvm.GetStoredEvents.(*dvm).searchDVMEvents.func1.1(0xc010aace70)
        /home/runner/work/subzero/subzero/dvm/events_storage.go:32 +0x87
github.com/jellydator/ttlcache/v3.(*Cache[...]).Range(0x364f0c0, 0xc03c0ab808)
        /home/runner/go/pkg/mod/github.com/jellydator/ttlcache/v3@v3.4.0/cache.go:599 +0x153
github.com/ice-blockchain/subzero/dvm.GetStoredEvents.(*dvm).searchDVMEvents.func1(0xc020b9f860)
        /home/runner/work/subzero/subzero/dvm/events_storage.go:30 +0x1f9
```