### PR TITLE
apply `betteralign`

### DIFF
--- a/database/command/global.go
+++ b/database/command/global.go
@@ -58,10 +58,10 @@ var (
 type Config struct {
 	AbsoluteRootPath           string `yaml:"absolute-root-path"`
 	AbsoluteNodePrivateKeyPath string `yaml:"absolute-node-private-key-path"`
-	DiscoveryPort              uint16 `yaml:"discovery-port"`
 	ExternalAddress            string `yaml:"external-address"`
-	Debug                      bool   `yaml:"debug"`
 	RelayUrl                   string `yaml:"relay-url"`
+	DiscoveryPort              uint16 `yaml:"discovery-port"`
+	Debug                      bool   `yaml:"debug"`
 }
 
 type Option func(*consensus)

--- a/database/query/client.go
+++ b/database/query/client.go
@@ -23,10 +23,10 @@ import (
 type (
 	dbClient struct {
 		db                 *connector.DB
-		hasReadURLs        bool
+		rollbackableEvents *xsync.Map[eventHash, *databaseRollbackRequest]
 		relayPrivateKey    string
 		relayURL           string
-		rollbackableEvents *xsync.Map[eventHash, *databaseRollbackRequest]
+		hasReadURLs        bool
 	}
 
 	eventHash [sha256.Size]byte

--- a/database/query/fixture/memdb.go
+++ b/database/query/fixture/memdb.go
@@ -11,8 +11,8 @@ import (
 )
 
 type MemDB struct {
-	mu     sync.RWMutex
 	events []*model.Event
+	mu     sync.RWMutex
 }
 
 func (m *MemDB) AcceptEvents(_ context.Context, events ...*model.Event) error {

--- a/database/query/internal/connector/contract.go
+++ b/database/query/internal/connector/contract.go
@@ -34,11 +34,11 @@ var (
 type (
 	Option func(context.Context, *DB) error
 	DB     struct {
-		ddl     string
-		logging bool
 		writeLB *writeLB
 		readLB  *readLB
 		closed  *atomic.Bool
+		ddl     string
+		logging bool
 	}
 	Iterator[T any] = iter.Seq2[T, error]
 	Error           = pgconn.PgError
@@ -51,12 +51,12 @@ type (
 		CurrentIndex uint64
 	}
 	writeLB struct {
+		Active                      atomic.Pointer[pgxpool.Pool]
+		CancelPreferredMasterSwitch context.CancelFunc
 		Masters                     []string
 		PreferredUrl                uint64
-		Active                      atomic.Pointer[pgxpool.Pool]
 		CurrentIndex                uint64
 		SwitchMu                    sync.Mutex
-		CancelPreferredMasterSwitch context.CancelFunc
 	}
 )
 

--- a/database/query/internal/connector/errors.go
+++ b/database/query/internal/connector/errors.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DuplicateError struct {
+	Original   error
 	Constraint string
 	Object     string
-	Original   error
 }
 
 type sanitizedError struct {

--- a/database/query/query.go
+++ b/database/query/query.go
@@ -45,12 +45,6 @@ type (
 
 	databaseEvent struct {
 		*model.Event
-		LookupCreatedAt         int64
-		TagID                   int64
-		Expiration              sql.NullInt64
-		ReferenceID             sql.NullString
-		GiftReceiver            sql.NullString
-		Ttags                   []string
 		SigAlg                  string
 		KeyAlg                  string
 		MasterPubKey            string
@@ -61,6 +55,12 @@ type (
 		SaveMergeAction         string
 		Origin                  string
 		SystemID                string
+		ReferenceID             sql.NullString
+		GiftReceiver            sql.NullString
+		Ttags                   []string
+		Expiration              sql.NullInt64
+		LookupCreatedAt         int64
+		TagID                   int64
 		Deleted                 bool
 		HasImages               bool
 		HasVideos               bool
@@ -81,10 +81,10 @@ type (
 		Empty() bool
 	}
 	byAuthorEventEnricher struct {
-		Kind       int                 // Target kind to enrich, like `nostr.KindProfileMetadata`.
 		Origin     map[string]struct{} // Origin of the event, i.e. source. Like `filter0_events_cte`.
 		KindOrigin map[string]struct{} // The loaded dependency origin, like `filter0_events_cte_dep9`.
 		Signer     func(event *databaseEvent)
+		Kind       int // Target kind to enrich, like `nostr.KindProfileMetadata`.
 	}
 	byAuthorKind0EventEnricher struct {
 		byAuthorEventEnricher
@@ -93,12 +93,12 @@ type (
 
 type databaseBatchRequest struct {
 	EventsHash *eventHash
+	// IDs of replaceable events to rollback update
+	Rollback map[string]bool
 	// Events to store or replace.
 	InsertOrReplace []databaseEvent
 	// Events to delete.
 	Delete []databaseFilterDelete
-	// IDs of replaceable events to rollback update
-	Rollback map[string]bool
 }
 
 func (d *databaseEvent) FromTags(tags model.Tags) {

--- a/database/query/query_where_builder.go
+++ b/database/query/query_where_builder.go
@@ -53,24 +53,21 @@ type (
 		strings.Builder
 	}
 	queryBuildResult struct {
-		Statement string
 		Params    map[string]any
 		Filters   map[string]*databaseFilterTree // Origin/cte name -> filter.
+		Statement string
 	}
 	queryBuilderValue struct {
+		Value  any
 		Name   string
 		CastTo string // If empty, no cast is applied.
 		Func   string // If non-empty, the value is passed to the function.
-		Value  any
 	}
 	databaseFilterTree struct {
 		Root  *databaseFilterSearch
 		Leafs map[string]*filterDependency // Origin/dependency name -> dependency.
 	}
 	databaseFilterSearch struct {
-		model.Filter
-		ID                string
-		SearchText        string
 		Expiration        *bool
 		Videos            *bool
 		Images            *bool
@@ -78,10 +75,13 @@ type (
 		Quotes            *bool
 		References        *bool
 		CurrentUserPubkey *string
-		TagMarkers        []databaseFilterMarker
-		Dependencies      []*filterDependency
-		Rank              rank
-		Extra             []string // Extra `where` clauses, ANDed to the main filter.
+		ID                string
+		SearchText        string
+		model.Filter
+		TagMarkers   []databaseFilterMarker
+		Dependencies []*filterDependency
+		Extra        []string // Extra `where` clauses, ANDed to the main filter.
+		Rank         rank
 	}
 	databaseFilterDelete struct {
 		Author        string
@@ -95,10 +95,10 @@ type (
 		Exclude bool
 	}
 	databaseCTE struct {
+		Filter  *databaseFilterSearch
 		Name    string
 		Body    string
 		OrderBy string
-		Filter  *databaseFilterSearch
 	}
 )
 
@@ -202,10 +202,10 @@ func (b *queryBuilder) MaybeOP(op int) {
 }
 
 type sliceBuilder[T comparable] struct {
-	Slice     []T
-	Negative  bool
 	ParamName string
+	Slice     []T
 	Op        int
+	Negative  bool
 }
 
 func (b *sliceBuilder[T]) Build(builder *queryBuilder, filterID string, name string) *queryBuilder {

--- a/database/query/query_where_dependencies_parser.go
+++ b/database/query/query_where_dependencies_parser.go
@@ -13,16 +13,16 @@ type (
 	token = tokenizer.TokenKey
 
 	filterDependencyStart struct {
+		Tag           string
 		Kind          int
 		ProfileBadges bool
-		Tag           string
 	}
 
 	filterDependencyReduce struct {
-		Kinds      []int
 		Author     string
 		Tag        string
 		Context    string
+		Kinds      []int
 		Group      bool
 		Expiration bool
 	}

--- a/hashtags-sender/hashtagssender.go
+++ b/hashtags-sender/hashtagssender.go
@@ -29,12 +29,12 @@ type (
 		Events []*model.Event `json:"events"`
 	}
 	sender struct {
-		eventsToSend chan []*model.Event
-		mu           sync.Mutex
 		lastSent     time.Time
+		eventsToSend chan []*model.Event
 		config       *Config
 		client       *req.Client
 		eventsQueue  []*model.Event
+		mu           sync.Mutex
 	}
 )
 

--- a/model/content.go
+++ b/model/content.go
@@ -17,8 +17,8 @@ import (
 
 type (
 	deltaOperation struct {
-		Insert     json.RawMessage            `json:"insert"`
 		Attributes map[string]json.RawMessage `json:"attributes,omitempty"`
+		Insert     json.RawMessage            `json:"insert"`
 	}
 	deltaInsertObject struct {
 		TextEditorProfile     string `json:"text-editor-profile,omitempty"`

--- a/model/context.go
+++ b/model/context.go
@@ -8,12 +8,12 @@ import (
 
 type (
 	UserDataContext struct {
+		Kinds           map[int]struct{}
 		PublicKey       string
 		MasterPublicKey string
 		UserAgent       string
 		Authenticated   bool
 		Authoritative   bool
-		Kinds           map[int]struct{}
 	}
 	userKey string
 )

--- a/model/event.go
+++ b/model/event.go
@@ -19,8 +19,8 @@ import (
 
 type (
 	Event struct {
-		nostr.Event
 		Previous *Event `db:"-" json:"-" swaggerignore:"true"` // Previous version of the event, if any.
+		nostr.Event
 	}
 	Events                  []*Event
 	EventSignAlg            string

--- a/model/model.go
+++ b/model/model.go
@@ -144,7 +144,8 @@ type (
 	JobFeedbackStatus      string
 	Role                   string
 	ProfileMetadataContent struct {
-		RegisteredAt             Timestamp                                                       `json:"registered_at" `
+		IONContentNFTCollections map[IONContentNFTCollectionName]IONContentNFTCollectionMetadata `json:"ion_content_nft_collections" `
+		Wallets                  map[string]string                                               `json:"wallets"`
 		Name                     string                                                          `json:"name" example:"username"`
 		About                    string                                                          `json:"about" example:"about"`
 		Picture                  string                                                          `json:"picture" example:"https://example.com/pic.jpg"`
@@ -152,11 +153,10 @@ type (
 		Website                  string                                                          `json:"website" example:"https://ice.io"`
 		Banner                   string                                                          `json:"banner" example:"https://example.com/banner.jpg"`
 		Location                 string                                                          `json:"location" example:"New York, USA"`
-		IONContentNFTCollections map[IONContentNFTCollectionName]IONContentNFTCollectionMetadata `json:"ion_content_nft_collections" `
 		Category                 string                                                          `json:"category" example:"Crypto"`
 		WhoCanMessageYou         string                                                          `json:"who_can_message_you" example:"friends"`
 		WhoCanInviteYouToGroups  string                                                          `json:"who_can_invite_you_to_groups" example:"friends"`
-		Wallets                  map[string]string                                               `json:"wallets"`
+		RegisteredAt             Timestamp                                                       `json:"registered_at" `
 		Bot                      bool                                                            `json:"bot" example:"false"`
 	}
 	IONContentNFTCollectionName     string

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -10,15 +10,14 @@ import (
 
 type (
 	Subscription struct {
-		ID      string
-		Filters Filters
-		OneShot bool
-
-		live      atomic.Bool
 		addresses map[string]int
-		pending   Events
 		reduce    func(*Event) (skip bool)
+		ID        string
+		Filters   Filters
+		pending   Events
 		mu        sync.Mutex
+		live      atomic.Bool
+		OneShot   bool
 	}
 )
 

--- a/open-telemetry/logging_setup.go
+++ b/open-telemetry/logging_setup.go
@@ -165,15 +165,15 @@ func (bp *batchProcessorWrapper) Enabled(_ context.Context, param otelsdklog.Ena
 }
 
 type redundantLogExporter struct {
+	fallback           otelsdklog.Exporter
+	primaryLifecycleMx *sync.RWMutex
+
+	logWALBackup        *wal.Log
 	primaries           []otelsdklog.Exporter
-	fallback            otelsdklog.Exporter
 	currentPrimaryIndex uint64
 
 	primaryExporterEnabled bool
 	logWALBackupEmpty      bool
-	primaryLifecycleMx     *sync.RWMutex
-
-	logWALBackup *wal.Log
 }
 
 func (re *redundantLogExporter) Export(ctx context.Context, records []otelsdklog.Record) error {
@@ -319,14 +319,15 @@ func (re *redundantLogExporter) ForceFlush(ctx context.Context) error {
 }
 
 type walLogRecord struct {
+	Timestamp time.Time `json:"timestamp"`
+
+	Attributes   map[string]any `json:"attributes"`
+	SeverityText string         `json:"severityText"`
+	Body         string         `json:"body"`
+
 	actualLogRecord otelsdklog.Record
 
-	Timestamp    time.Time        `json:"timestamp"`
-	Severity     otellog.Severity `json:"severity"`
-	SeverityText string           `json:"severityText"`
-	Body         string           `json:"body"`
-
-	Attributes map[string]any `json:"attributes"`
+	Severity otellog.Severity `json:"severity"`
 }
 
 func (re *walLogRecord) MarshallJSON() ([]byte, error) {

--- a/open-telemetry/tracing_setup.go
+++ b/open-telemetry/tracing_setup.go
@@ -74,15 +74,15 @@ func (t *telemetry) mustInitTracingProvider(ctx context.Context, res *otelsdkres
 }
 
 type redundantTraceExporter struct {
+	fallback           otelsdktrace.SpanExporter
+	primaryLifecycleMx *sync.RWMutex
+
+	traceWALBackup      *wal.Log
 	primaries           []otelsdktrace.SpanExporter
-	fallback            otelsdktrace.SpanExporter
 	currentPrimaryIndex uint64
 
 	primaryExporterEnabled bool
 	traceWALBackupEmpty    bool
-	primaryLifecycleMx     *sync.RWMutex
-
-	traceWALBackup *wal.Log
 }
 
 func (re *redundantTraceExporter) ExportSpans(ctx context.Context, spans []otelsdktrace.ReadOnlySpan) error {
@@ -201,25 +201,26 @@ func (re *redundantTraceExporter) Shutdown(ctx context.Context) error {
 }
 
 type walTraceSpan struct {
-	actualTraceSpan otelsdktrace.ReadOnlySpan
-
-	//TODO see if all those fields are serialised properly
-	Name                 string                       `json:"name,omitempty"`
-	SpanContext          oteltrace.SpanContext        `json:"spanContext,omitempty"`
-	Parent               oteltrace.SpanContext        `json:"parent,omitempty"`
-	SpanKind             oteltrace.SpanKind           `json:"spanKind,omitempty"`
+	InstrumentationScope otelsdkinstrumentation.Scope `json:"instrumentationScope,omitempty"`
 	StartTime            time.Time                    `json:"startTime,omitempty"`
 	EndTime              time.Time                    `json:"endTime,omitempty"`
-	Attributes           []otelattribute.KeyValue     `json:"attributes,omitempty"`
-	Links                []otelsdktrace.Link          `json:"links,omitempty"`
-	Events               []otelsdktrace.Event         `json:"events,omitempty"`
-	Status               otelsdktrace.Status          `json:"status,omitempty"`
-	InstrumentationScope otelsdkinstrumentation.Scope `json:"instrumentationScope,omitempty"`
-	Resource             *otelsdkresource.Resource    `json:"resource,omitempty"`
-	DroppedAttributes    int                          `json:"droppedAttributes,omitempty"`
-	DroppedLinks         int                          `json:"droppedLinks,omitempty"`
-	DroppedEvents        int                          `json:"droppedEvents,omitempty"`
-	ChildSpanCount       int                          `json:"childSpanCount,omitempty"`
+	actualTraceSpan      otelsdktrace.ReadOnlySpan
+
+	Resource *otelsdkresource.Resource `json:"resource,omitempty"`
+	Status   otelsdktrace.Status       `json:"status,omitempty"`
+
+	//TODO see if all those fields are serialised properly
+	Name              string                   `json:"name,omitempty"`
+	Attributes        []otelattribute.KeyValue `json:"attributes,omitempty"`
+	Links             []otelsdktrace.Link      `json:"links,omitempty"`
+	Events            []otelsdktrace.Event     `json:"events,omitempty"`
+	SpanContext       oteltrace.SpanContext    `json:"spanContext,omitempty"`
+	Parent            oteltrace.SpanContext    `json:"parent,omitempty"`
+	SpanKind          oteltrace.SpanKind       `json:"spanKind,omitempty"`
+	DroppedAttributes int                      `json:"droppedAttributes,omitempty"`
+	DroppedLinks      int                      `json:"droppedLinks,omitempty"`
+	DroppedEvents     int                      `json:"droppedEvents,omitempty"`
+	ChildSpanCount    int                      `json:"childSpanCount,omitempty"`
 }
 
 func (re *walTraceSpan) MarshallJSON() ([]byte, error) {

--- a/push-notifications/devices.go
+++ b/push-notifications/devices.go
@@ -21,8 +21,8 @@ import (
 type (
 	DeviceID   = pn.DeviceID
 	DeviceInfo struct {
-		Filters model.Filters
 		Event   *model.Event
+		Filters model.Filters
 	}
 )
 

--- a/push-notifications/internal/pushnotifications.go
+++ b/push-notifications/internal/pushnotifications.go
@@ -38,8 +38,8 @@ type (
 	}
 	notificationClient struct {
 		client     *messaging.Client
-		retry      RetryConfig
 		privateKey string
+		retry      RetryConfig
 	}
 	Notification[TARGET SubscriptionTopic | *DeviceRegistrationEvent] struct {
 		Data     map[string]interface{} `json:"data,omitempty"`
@@ -58,9 +58,9 @@ type (
 
 	options struct {
 		credentialsFile string
+		privateKey      string
 		credentialsJSON []byte
 		retryConfig     RetryConfig
-		privateKey      string
 	}
 )
 

--- a/push-notifications/pushnotifications.go
+++ b/push-notifications/pushnotifications.go
@@ -31,9 +31,9 @@ type (
 
 	PushNotificationManager struct {
 		userDevicesMap         map[PublicKey]map[DeviceID]DeviceInfo
-		deviceMutex            sync.RWMutex
 		pushNotificationClient *pn.Client
 		relayURL               string
+		deviceMutex            sync.RWMutex
 	}
 
 	notificationTranslation struct {
@@ -44,11 +44,11 @@ type (
 
 	config struct {
 		FCMCredentialsFile string   `yaml:"fcm-credentials-file"`
+		PrivateKey         string   `yaml:"private-key"`
+		RelayURL           string   `yaml:"relay-url"`
 		FCMAndroidConfigs  []string `yaml:"fcm-android-configs"`
 		FCMIOSConfigs      []string `yaml:"fcm-ios-configs"`
 		FCMWebConfigs      []string `yaml:"fcm-web-configs"`
-		PrivateKey         string   `yaml:"private-key"`
-		RelayURL           string   `yaml:"relay-url"`
 	}
 )
 

--- a/server/broadcaster/broadcast.go
+++ b/server/broadcaster/broadcast.go
@@ -29,9 +29,9 @@ type (
 		mu     sync.RWMutex
 	}
 	Config struct {
+		QueryFunc  func(ctx context.Context, filters ...model.Filter) query.EventIterator
 		RelayURL   string
 		PrivateKey string
-		QueryFunc  func(ctx context.Context, filters ...model.Filter) query.EventIterator
 	}
 )
 

--- a/server/http/nip11/nip11.go
+++ b/server/http/nip11/nip11.go
@@ -39,24 +39,24 @@ type (
 		UsedBandwidth       uint64 `json:"used_bandwidth"`
 	}
 	RelayInformationDocument struct {
-		nip11.RelayInformationDocument `json:",inline"`
-		FCMAndroidConfigs              []FCMConfig    `json:"fcm_android_configs"`
-		FCMIOSConfigs                  []FCMConfig    `json:"fcm_ios_configs"`
-		FCMWebConfigs                  []FCMConfig    `json:"fcm_web_configs"`
 		SystemMetrics                  *SystemMetrics `json:"system_metrics,omitempty"`
+		nip11.RelayInformationDocument `json:",inline"`
+		FCMAndroidConfigs              []FCMConfig `json:"fcm_android_configs"`
+		FCMIOSConfigs                  []FCMConfig `json:"fcm_ios_configs"`
+		FCMWebConfigs                  []FCMConfig `json:"fcm_web_configs"`
 	}
 	Config struct {
-		MinLeadingZeroBits int
+		PrivateKey         string
 		FCMAndroidConfigs  []string
 		FCMIOSConfigs      []string
 		FCMWebConfigs      []string
-		PrivateKey         string
+		MinLeadingZeroBits int
 	}
 	nip11handler struct {
 		cfg                  *Config
+		systemMetrics        *atomic.Pointer[SystemMetrics]
 		storagePath          string
 		commandPath          string
-		systemMetrics        *atomic.Pointer[SystemMetrics]
 		lastBandwidthBytes   uint64
 		lastBandwidthBytesAt int64
 	}

--- a/server/http/nip96/storage_nip96.go
+++ b/server/http/nip96/storage_nip96.go
@@ -64,18 +64,18 @@ type (
 		Message       string `json:"message"`
 		ProcessingURL string `json:"processing_url"`
 		Nip94Event    struct {
-			Tags    nostr.Tags `json:"tags"`
 			Content string     `json:"content"`
+			Tags    nostr.Tags `json:"tags"`
 		} `json:"nip94_event"`
 	}
 	listedFiles struct {
-		Total uint32 `json:"total"`
-		Page  uint32 `json:"page"`
 		Files []struct {
-			Tags      nostr.Tags `json:"tags"`
 			Content   string     `json:"content"`
+			Tags      nostr.Tags `json:"tags"`
 			CreatedAt uint64     `json:"created_at"`
 		}
+		Total uint32 `json:"total"`
+		Page  uint32 `json:"page"`
 	}
 )
 
@@ -149,8 +149,8 @@ func (s *storageHandler) Upload() gin.HandlerFunc {
 			Status:  "success",
 			Message: "Upload successful.",
 			Nip94Event: struct {
-				Tags    nostr.Tags `json:"tags"`
 				Content string     `json:"content"`
+				Tags    nostr.Tags `json:"tags"`
 			}{
 				Tags: nostr.Tags{
 					nostr.Tag{"url", url},
@@ -323,15 +323,15 @@ func (s *storageHandler) ListFiles() gin.HandlerFunc {
 			Total: total,
 			Page:  params.Page,
 			Files: []struct {
-				Tags      nostr.Tags `json:"tags"`
 				Content   string     `json:"content"`
+				Tags      nostr.Tags `json:"tags"`
 				CreatedAt uint64     `json:"created_at"`
 			}{},
 		}
 		for _, f := range filesList {
 			res.Files = append(res.Files, struct {
-				Tags      nostr.Tags `json:"tags"`
 				Content   string     `json:"content"`
+				Tags      nostr.Tags `json:"tags"`
 				CreatedAt uint64     `json:"created_at"`
 			}{Tags: f.ToTags(), Content: f.Content, CreatedAt: f.CreatedAt})
 		}

--- a/server/http/nip96/storage_tus.go
+++ b/server/http/nip96/storage_tus.go
@@ -220,8 +220,8 @@ func (s *storageHandler) PreFinishResponseCallback(hook tusd.HookEvent) (tusd.HT
 		Status:  "success",
 		Message: "Upload successful.",
 		Nip94Event: struct {
-			Tags    nostr.Tags `json:"tags"`
 			Content string     `json:"content"`
+			Tags    nostr.Tags `json:"tags"`
 		}{
 			Tags: nostr.Tags{
 				{"url", url},

--- a/server/server.go
+++ b/server/server.go
@@ -33,14 +33,14 @@ type (
 		TLSCert             string `yaml:"tls-cert"`
 		TLSKey              string `yaml:"tls-key"`
 		RelayURL            string `yaml:"relay-url"     validate:"required,url"`
-		Port                uint16 `yaml:"port"          validate:"required,min=1,max=65535"`
-		IONLibertyDisabled  bool   `yaml:"ion-liberty-disabled"`
-		Debug               bool   `yaml:"debug"`
 		PrivateKey          string `yaml:"private-key"`
 		BroadcastPrivateKey string `yaml:"broadcast-private-key" validate:"required"`
 		ACME                struct {
 			APIKey string `yaml:"api-key"`
 		} `yaml:"acme"`
+		Port               uint16 `yaml:"port"          validate:"required,min=1,max=65535"`
+		IONLibertyDisabled bool   `yaml:"ion-liberty-disabled"`
+		Debug              bool   `yaml:"debug"`
 	}
 	Option func(*router)
 

--- a/server/ws/contract.go
+++ b/server/ws/contract.go
@@ -35,8 +35,8 @@ var (
 
 type (
 	connAuthData struct {
-		Challenge string
 		model.UserDataContext
+		Challenge string
 	}
 	subscription struct {
 		Source *model.Subscription

--- a/server/ws/internal/adapters/contract.go
+++ b/server/ws/internal/adapters/contract.go
@@ -40,34 +40,34 @@ type (
 		Write(ctx context.Context)
 	}
 	WebtransportAdapterConfig struct {
+		CloseChannel <-chan struct{}
+		Handshake    ws.Handshake
 		WriteTimeout time.Duration
 		ReadTimeout  time.Duration
-		Handshake    ws.Handshake
-		CloseChannel <-chan struct{}
 	}
 	WebtransportAdapter struct {
 		stream       Stream
+		wrErr        error
 		session      *webtransport.Session
 		reader       *bufio.Reader
 		closeChannel chan struct{}
-		closed       atomic.Bool
-		wrErr        error
-		wrErrMx      sync.Mutex
 		out          chan []byte
 		writeTimeout time.Duration
 		readTimeout  time.Duration
+		wrErrMx      sync.Mutex
+		closed       atomic.Bool
 	}
 
 	WebsocketAdapter struct {
 		conn         net.Conn
+		wrErr        error
 		out          chan wsWrite
 		closeChannel chan struct{}
-		wrErr        error
-		wrErrMx      sync.Mutex
-		closed       atomic.Bool
+		framer       func(int, []byte) (ws.Frame, error)
 		writeTimeout time.Duration
 		readTimeout  time.Duration
-		framer       func(int, []byte) (ws.Frame, error)
+		wrErrMx      sync.Mutex
+		closed       atomic.Bool
 	}
 )
 

--- a/server/ws/internal/config/contract.go
+++ b/server/ws/internal/config/contract.go
@@ -10,9 +10,9 @@ import (
 type (
 	Config struct {
 		TLSConfig    *tls.Config
-		Port         uint16        `yaml:"port"`
 		WriteTimeout time.Duration `yaml:"writeTimeout"`
 		ReadTimeout  time.Duration `yaml:"readTimeout"`
+		Port         uint16        `yaml:"port"`
 		Debug        bool          `yaml:"debug"`
 	}
 )

--- a/storage/global.go
+++ b/storage/global.go
@@ -49,10 +49,10 @@ type (
 		IONStorageConfigURL     string `yaml:"ion-storage-config-url"`
 		AbsoluteRootStoragePath string `yaml:"absolute-root-storage-path"`
 		ExternalADNLAddress     string `yaml:"external-adnl-address"`
+		RelayURL                string `yaml:"relay-url"`
 		ExternalADNLPort        int    `yaml:"external-adnl-port"`
 		Debug                   bool   `yaml:"debug"`
 		IONLibertyDisabled      bool   `yaml:"ion-liberty-disabled"`
-		RelayURL                string `yaml:"relay-url"`
 	}
 	Option     func(*client)
 	acceptorFn func(ctx context.Context, fh, master, infohash string) error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -58,11 +58,11 @@ type (
 		Caption     string `json:"c"`
 		Alt         string `json:"a"`
 		Owner       string `json:"o"`
+		ContentType string `json:"-"`
+		Filename    string `json:"-"`
 		Hash        []byte `json:"h"`
 		CreatedAt   uint64 `json:"cAt"`
-		ContentType string `json:"-"`
 		FileSize    uint64 `json:"-"`
-		Filename    string `json:"-"`
 	}
 	FileMetadata struct {
 		*nip94.FileMetadata
@@ -81,9 +81,9 @@ type (
 		downloadQueue     chan queueItem
 		activeDownloads   map[string]bool
 		activeDownloadsMx *sync.RWMutex
+		config            *Config
 		rootStoragePath   string
 		closed            atomic.Bool
-		config            *Config
 	}
 	queueItem struct {
 		tor       *storage.Torrent

--- a/validation/config.go
+++ b/validation/config.go
@@ -8,11 +8,11 @@ import (
 
 type (
 	Config struct {
-		MaxWrappedEventExpiration time.Duration `yaml:"max-wrapped-event-expiration"`
 		MaxContentSizes           map[int]int   `yaml:"max-content-sizes"` // Kind -> size (bytes).
-		NIP13MinLeadingZeroBits   int           `yaml:"nip13MinLeadingZeroBits"`
 		RelayURL                  string        `yaml:"relay-url" validate:"omitempty,url"`
 		IONIdentityBaseURL        string        `yaml:"ion-identity-base-url" validate:"omitempty,url"`
+		MaxWrappedEventExpiration time.Duration `yaml:"max-wrapped-event-expiration"`
+		NIP13MinLeadingZeroBits   int           `yaml:"nip13MinLeadingZeroBits"`
 	}
 )
 

--- a/validation/global.go
+++ b/validation/global.go
@@ -12,8 +12,8 @@ import (
 
 var (
 	global struct {
-		sync.Once
 		Validator *eventValidator
+		sync.Once
 	}
 )
 

--- a/validation/internal/ion-identity-pubkeys/ion_identity_pubkeys.go
+++ b/validation/internal/ion-identity-pubkeys/ion_identity_pubkeys.go
@@ -23,8 +23,8 @@ type (
 		Stored atomic.Pointer[publicKeys]
 	}
 	publicKeys struct {
-		Keys    []string
 		Version string
+		Keys    []string
 	}
 )
 

--- a/validation/validate.go
+++ b/validation/validate.go
@@ -33,18 +33,18 @@ const (
 type (
 	tagState uint
 	tagData  struct {
-		// Tag state, one of: required, optional, forbidden, etc.
-		State tagState
 		// Additional tags.
 		Tags []string
+		// Tag state, one of: required, optional, forbidden, etc.
+		State tagState
 	}
 	kindValidator struct {
 		// Tag map: tag key -> tag state.
 		Tags map[string]tagData
-		// Additional flags for given kind.
-		Flags uint
 		// Additional validation function.
 		Validate func(v *eventValidator, e *model.Event) error
+		// Additional flags for given kind.
+		Flags uint
 	}
 )
 


### PR DESCRIPTION
```
model/content.go:19:17: 16 bytes saved: struct with 32 pointer bytes could be 16
model/context.go:10:18: 16 bytes saved: struct with 64 pointer bytes could be 48
model/event.go:21:8: 8 bytes saved: struct with 112 pointer bytes could be 104
model/model.go:146:25: 16 bytes saved: struct with 184 pointer bytes could be 168
model/subscription.go:12:15: 24 bytes saved: struct with 88 pointer bytes could be 64
database/query/internal/connector/contract.go:36:9: 16 bytes saved: struct with 48 pointer bytes could be 32
database/query/internal/connector/contract.go:53:10: 40 bytes saved: struct with 64 pointer bytes could be 24
database/query/internal/connector/errors.go:14:21: 8 bytes saved: struct with 48 pointer bytes could be 40
database/query/client.go:24:11: 16 bytes saved: struct with 56 pointer bytes could be 40
database/query/query.go:46:16: 40 bytes saved: struct with 264 pointer bytes could be 224
database/query/query.go:83:24: 8 bytes saved: struct with 32 pointer bytes could be 24
database/query/query.go:94:27: 16 bytes saved: struct with 64 pointer bytes could be 48
database/query/query_where_builder.go:55:19: 8 bytes saved: struct with 32 pointer bytes could be 24
database/query/query_where_builder.go:60:20: 8 bytes saved: struct with 64 pointer bytes could be 56
database/query/query_where_builder.go:70:23: 8 bytes saved: struct with 304 pointer bytes could be 296
database/query/query_where_builder.go:97:14: 8 bytes saved: struct with 56 pointer bytes could be 48
database/query/query_where_builder.go:204:33: 16 bytes saved: struct with 40 pointer bytes could be 24
database/query/query_where_builder_filter.go:13:13: 8 bytes saved: struct with 24 pointer bytes could be 16
database/query/query_where_dependencies_parser.go:15:24: 16 bytes saved: struct with 24 pointer bytes could be 8
database/query/query_where_dependencies_parser.go:21:25: 8 bytes saved: struct with 64 pointer bytes could be 56
database/command/global.go:58:13: 8 bytes saved: struct of size 80 could be 72
hashtags-sender/hashtagssender.go:31:9: 8 bytes saved: struct with 64 pointer bytes could be 56
push-notifications/internal/pushnotifications.go:39:21: 24 bytes saved: struct with 40 pointer bytes could be 16
push-notifications/internal/pushnotifications.go:59:10: 32 bytes saved: struct with 72 pointer bytes could be 40
validation/internal/ion-identity-pubkeys/ion_identity_pubkeys.go:25:13: 8 bytes saved: struct with 32 pointer bytes could be 24
validation/config.go:10:9: 16 bytes saved: struct with 48 pointer bytes could be 32
validation/global.go:14:9: 16 bytes saved: struct with 24 pointer bytes could be 8
validation/validate.go:35:11: 8 bytes saved: struct with 16 pointer bytes could be 8
validation/validate.go:41:16: 8 bytes saved: struct with 24 pointer bytes could be 16
push-notifications/devices.go:23:13: 16 bytes saved: struct with 32 pointer bytes could be 16
push-notifications/pushnotifications.go:38:26: 24 bytes saved: struct with 48 pointer bytes could be 24
push-notifications/pushnotifications.go:51:9: 8 bytes saved: struct with 112 pointer bytes could be 104
server/broadcaster/broadcast.go:31:9: 8 bytes saved: struct with 40 pointer bytes could be 32
server/http/nip11/nip11.go:41:27: 16 bytes saved: struct with 352 pointer bytes could be 336
server/http/nip11/nip11.go:48:9: 16 bytes saved: struct with 88 pointer bytes could be 72
server/http/nip11/nip11.go:55:15: 8 bytes saved: struct with 48 pointer bytes could be 40
storage/global.go:47:9: 16 bytes saved: struct with 88 pointer bytes could be 72
storage/storage.go:57:16: 24 bytes saved: struct with 112 pointer bytes could be 88
storage/storage.go:71:9: 16 bytes saved: struct with 136 pointer bytes could be 120
server/http/nip96/storage_nip96.go:66:17: 8 bytes saved: struct with 32 pointer bytes could be 24
server/http/nip96/storage_nip96.go:71:14: 8 bytes saved: struct with 16 pointer bytes could be 8
server/http/nip96/storage_nip96.go:74:11: 8 bytes saved: struct with 32 pointer bytes could be 24
server/http/nip96/storage_nip96.go:151:16: 8 bytes saved: struct with 32 pointer bytes could be 24
server/http/nip96/storage_nip96.go:325:13: 8 bytes saved: struct with 32 pointer bytes could be 24
server/http/nip96/storage_nip96.go:332:34: 8 bytes saved: struct with 32 pointer bytes could be 24
server/http/nip96/storage_tus.go:222:15: 8 bytes saved: struct with 32 pointer bytes could be 24
server/ws/internal/adapters/contract.go:42:28: 32 bytes saved: struct with 64 pointer bytes could be 32
server/ws/internal/adapters/contract.go:48:22: 16 bytes saved: struct with 80 pointer bytes could be 64
server/ws/internal/adapters/contract.go:61:19: 32 bytes saved: struct with 88 pointer bytes could be 56
server/ws/internal/config/contract.go:11:9: 8 bytes saved: struct of size 40 could be 32
server/ws/contract.go:37:15: 8 bytes saved: struct with 80 pointer bytes could be 72
server/server.go:32:9: 8 bytes saved: struct with 96 pointer bytes could be 88
database/query/fixture/memdb.go:13:12: 24 bytes saved: struct with 32 pointer bytes could be 8
open-telemetry/logging_setup.go:167:27: 32 bytes saved: struct with 72 pointer bytes could be 40
open-telemetry/logging_setup.go:321:19: 40 bytes saved: struct with 504 pointer bytes could be 464
open-telemetry/tracing_setup.go:76:29: 32 bytes saved: struct with 72 pointer bytes could be 40
open-telemetry/tracing_setup.go:203:19: 32 bytes saved: struct with 384 pointer bytes could be 352
```